### PR TITLE
Implement daily webhook rotation

### DIFF
--- a/env
+++ b/env
@@ -2,5 +2,5 @@ DISCORD_BOT_TOKEN=dein_bot_token_hier
 
 DISCORD_CLIENT_ID=deine_client_id_hier
 
-# Ielchen Kanälen ist der Bot aktiv ? (durch Komma trennen)
+# In welchen Kanälen ist der Bot aktiv ? (durch Komma trennen)
 ALLOWED_CHANNEL_IDS=id_von_kanal_1,id_von_kanal_2

--- a/env
+++ b/env
@@ -1,2 +1,6 @@
-DISCORD_BOT_TOKEN=
-DISCORD_CLIENT_ID=
+DISCORD_BOT_TOKEN=dein_bot_token_hier
+
+DISCORD_CLIENT_ID=deine_client_id_hier
+
+# Ielchen Kanälen ist der Bot aktiv ? (durch Komma trennen)
+ALLOWED_CHANNEL_IDS=id_von_kanal_1,id_von_kanal_2


### PR DESCRIPTION
This commit replaces the hourly webhook verification task with a proactive, 24-hour rotation cycle.

The new rotateWebhooks() function runs daily to delete the existing webhook for each managed channel and create a new one in its place.

This new process also implicitly handles stale or deleted webhooks, making the previous cleanupWebhooks function redundant. The database schema has been simplified by removing the now-unnecessary lastUsedAt column.